### PR TITLE
use pg_roles instead of pg_authid

### DIFF
--- a/src/pg_index.c
+++ b/src/pg_index.c
@@ -31,7 +31,7 @@ SELECT \
 FROM pg_index i \
 JOIN pg_class ic ON ic.oid = i.indexrelid \
 JOIN pg_namespace n ON n.oid = ic.relnamespace \
-JOIN pg_authid a ON a.oid = ic.relowner \
+JOIN pg_roles a ON a.oid = ic.relowner \
 JOIN pg_class t ON t.oid = i.indrelid \
 JOIN pg_am m ON m.oid = ic.relam"
 

--- a/src/pg_index.c
+++ b/src/pg_index.c
@@ -276,7 +276,7 @@ int    PG_INDEX_SIZE(AGENT_REQUEST *request, AGENT_RESULT *result)
     zabbix_log(LOG_LEVEL_DEBUG, "In %s()", __function_name);
     
     // Parse parameters
-    // index = get_rparam(request, PARAM_FIRST);
+    index = get_rparam(request, PARAM_FIRST);
     
     // Build query  
     if(NULL == index || '\0' == *index)

--- a/src/pg_index.c
+++ b/src/pg_index.c
@@ -35,7 +35,7 @@ JOIN pg_roles a ON a.oid = ic.relowner \
 JOIN pg_class t ON t.oid = i.indrelid \
 JOIN pg_am m ON m.oid = ic.relam"
 
-#define PGSQL_GET_INDEX_SIZE        "SELECT (relpages * 8192) FROM pg_class WHERE (relkind='i' AND relname = '%s')"
+#define PGSQL_GET_INDEX_SIZE        "SELECT (CAST(relpages AS bigint) * 8192) FROM pg_class WHERE (relkind='i' AND relname = '%s')"
 
 #define PGSQL_GET_INDEX_SIZE_SUM    "SELECT (SUM(relpages) * 8192) FROM pg_class WHERE relkind='i'"
 

--- a/src/pg_table.c
+++ b/src/pg_table.c
@@ -43,7 +43,7 @@ SELECT \
 FROM pg_class c \
 JOIN pg_namespace n ON c.relnamespace = n.oid \
 JOIN pg_type t ON c.reltype = t.oid \
-JOIN pg_authid a ON c.relowner = a.oid \
+JOIN pg_roles a ON c.relowner = a.oid \
 WHERE c.relkind='r'"
 
 #define PGSQL_DISCOVER_TABLE_CHILDREN   "SELECT c.oid , c.relname, n.nspname FROM pg_inherits i JOIN pg_class c ON i.inhrelid = c.oid JOIN pg_namespace n ON c.relnamespace = n.oid WHERE i.inhparent = '%s'::regclass"

--- a/src/pg_table.c
+++ b/src/pg_table.c
@@ -56,7 +56,7 @@ WHERE c.relkind='r'"
 
 #define PGSQL_GET_TABLE_STATIO_SUM  "SELECT SUM(%s) FROM pg_statio_all_tables"
 
-#define PGSQL_GET_TABLE_SIZE        "SELECT (relpages * 8192) FROM pg_class WHERE relkind='r' AND relname = '%s'"
+#define PGSQL_GET_TABLE_SIZE        "SELECT (CAST(relpages AS bigint) * 8192) FROM pg_class WHERE relkind='r' AND relname = '%s'"
 
 #define PGSQL_GET_TABLE_SIZE_SUM    "SELECT (SUM(relpages) * 8192) FROM pg_class WHERE relkind='r'"
 
@@ -66,7 +66,7 @@ WHERE c.relkind='r'"
 
 #define PGSQL_GET_TABLE_CHILD_COUNT "SELECT COUNT(i.inhrelid) FROM pg_inherits i WHERE i.inhparent = '%s'::regclass"
 
-#define PGSQL_GET_CHILDREN_SIZE     "SELECT SUM(c.relpages * 8192) FROM pg_inherits i JOIN pg_class c ON inhrelid = c.oid WHERE i.inhparent = '%s'::regclass"
+#define PGSQL_GET_CHILDREN_SIZE     "SELECT (SUM(c.relpages) * 8192) FROM pg_inherits i JOIN pg_class c ON inhrelid = c.oid WHERE i.inhparent = '%s'::regclass"
 
 #define PGSQL_GET_CHILDREN_ROWS     "SELECT SUM(c.reltuples) FROM pg_inherits i JOIN pg_class c ON inhrelid = c.oid WHERE i.inhparent = '%s'::regclass"
 

--- a/src/pg_tablespace.c
+++ b/src/pg_tablespace.c
@@ -19,7 +19,7 @@
 
 #include "libzbxpgsql.h"
 
-#define PGSQL_DISCOVER_TABLESPACES  "SELECT t.oid, t.spcname, a.rolname from pg_tablespace t JOIN pg_authid a ON a.oid = t.spcowner"
+#define PGSQL_DISCOVER_TABLESPACES  "SELECT t.oid, t.spcname, a.rolname from pg_tablespace t JOIN pg_roles a ON a.oid = t.spcowner"
 
 #define PGSQL_GET_TS_SIZE       "SELECT pg_tablespace_size('%s')"
 /*


### PR DESCRIPTION
The view pg_roles provides access to information about database roles. This is simply a publicly readable view of pg_authid that blanks out the password field. (http://www.postgresql.org/docs/9.4/static/view-pg-roles.html)