### PR TITLE
Add pg.query2.* keys to read SQL from config file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+v1.1.0 19 Aug 2016
+
+* Implemented `pg.query2.*` keys - Rob Brucks
+
 v1.0.0 26 Jun 2016
 
 * Added support for Zabbix v3

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libzbxpgsql], [1.0.0], [ryan@cavaliercoder.com])
+AC_INIT([libzbxpgsql], [1.1.0], [ryan@cavaliercoder.com])
 AM_INIT_AUTOMAKE([-Wall -Werror -Wno-portability foreign])
 m4_pattern_allow([AM_PROG_AR])
 AM_PROG_AR

--- a/query.conf
+++ b/query.conf
@@ -1,0 +1,24 @@
+# file: /etc/libzbxpgsql.d/query.conf
+# 
+# This file contains SQL to be executed by `pg_query2.*` keys
+# It is parsed by the C libconfig module 
+#    http://www.hyperrealm.com/main.php?s=libconfig
+#
+# The format of the file is:
+#   SQLkey = "SQL statement"
+#
+# SQL must be enclosed in double quotes.  Double quotes
+# inside the SQL must be escaped with a backslash.
+#
+# Any syntax error in the file will prevent the entire
+# file from being parsed correctly.
+#
+# SQL statements can span multiple lines:
+#   longsql = "select count(*)
+#                from pg_stat_activity;"
+#
+#  Testing Queries
+test1 = "SELECT 'Lorem ipsum dolor';"
+test2 = "SELECT pg_backend_pid();"
+test3 = "SELECT CAST(1234 AS double precision);"
+test4 = "SELECT * FROM pg_database;"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,6 +12,7 @@ libzbxpgsql_la_SOURCES = \
 	pg_namespace.c \
 	pg_params.c \
 	pg_query.c \
+	pg_query2.c \
 	pg_server.c \
 	pg_setting.c \
 	pg_table.c \
@@ -26,6 +27,7 @@ libzbxpgsql_la_CFLAGS = \
 
 libzbxpgsql_la_LDFLAGS = \
 	-shared \
+	-lconfig \
 	-avoid-version
 
 # Prevent install of the redundant *.la files

--- a/src/libzbxpgsql.c
+++ b/src/libzbxpgsql.c
@@ -46,6 +46,12 @@ static ZBX_METRIC keys[] =
     {"pg.query.integer",            CF_HAVEPARAMS,  PG_QUERY,                       ",,SELECT pg_backend_pid();"},
     {"pg.query.double",             CF_HAVEPARAMS,  PG_QUERY,                       ",,SELECT CAST(1234 AS double precision);"},
     {"pg.query.discovery",          CF_HAVEPARAMS,  PG_QUERY,                       ",,SELECT * FROM pg_database;"},
+
+    // User queries from config file
+    {"pg.query2.string",            CF_HAVEPARAMS,  PG_QUERY2,                      ",,test1"},
+    {"pg.query2.integer",           CF_HAVEPARAMS,  PG_QUERY2,                      ",,test2"},
+    {"pg.query2.double",            CF_HAVEPARAMS,  PG_QUERY2,                      ",,test3"},
+    {"pg.query2.discovery",         CF_HAVEPARAMS,  PG_QUERY2,                      ",,test4"},
     
     // Client connection statistics
     {"pg.backends.count",           CF_HAVEPARAMS,  PG_BACKENDS_COUNT,              NULL},

--- a/src/libzbxpgsql.h
+++ b/src/libzbxpgsql.h
@@ -27,6 +27,11 @@
 // PostgreSQL headers
 #include <libpq-fe.h>
 
+// Reading Config Files
+#include <stdio.h>
+#include <stdlib.h>
+#include <libconfig.h>
+
 // Zabbix source headers
 #include <sysinc.h>
 #include <module.h>
@@ -108,6 +113,7 @@ int     PG_SETTING(AGENT_REQUEST *request, AGENT_RESULT *result);
 int     PG_SETTING_DISCOVERY(AGENT_REQUEST *request, AGENT_RESULT *result);
 
 int     PG_QUERY(AGENT_REQUEST *request, AGENT_RESULT *result);
+int     PG_QUERY2(AGENT_REQUEST *request, AGENT_RESULT *result);
 
 int     PG_BACKENDS_COUNT(AGENT_REQUEST *request, AGENT_RESULT *result);
 int     PG_BACKENDS_FREE(AGENT_REQUEST *request, AGENT_RESULT *result);

--- a/src/pg_query2.c
+++ b/src/pg_query2.c
@@ -1,0 +1,108 @@
+/*
+** libzbxpgsql - A PostgreSQL monitoring module for Zabbix
+** Copyright (C) 2015 - Ryan Armstrong <ryan@cavaliercoder.com>
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+#include "libzbxpgsql.h"
+
+/*
+ * Custom key pg.query2.*
+ *
+ * Returns the value of the first column of the first row returned by the
+ * specified SQL query.
+ *
+ * This is a clone of pg_query.c, but it reads SQL from the config file:
+ *   "/etc/libzbxpgsql/query.conf"
+ * (using the C library libconfig) instead of reading SQL from the zabbix key.
+ *
+ * Parameters:
+ *   0:  connection string
+ *   1:  connection database
+ *   2:  name of query to retrieve from config file
+ *   n:  query parameters
+ *
+ * Returns: u
+ */
+int     PG_QUERY2(AGENT_REQUEST *request, AGENT_RESULT *result)
+{
+    int         ret = SYSINFO_RET_FAIL;         // Request result code
+    const char  *__function_name = "PG_QUERY2";  // Function name for log file
+    char        *query = NULL, *queryname = NULL;
+    int         i = 0;
+    PGparams    params = NULL;
+    const char  *config_file = "/etc/libzbxpgsql.d/query.conf";  // Config file containing queries
+    const char  *queryconst;
+    config_t    cfg;
+
+    zabbix_log(LOG_LEVEL_DEBUG, "In %s()", __function_name);
+    config_init(&cfg);
+
+    // Get the user SQL query name parameter
+    queryname = get_rparam(request, PARAM_FIRST);
+    if(NULL == queryname || '\0' == *queryname) {
+        set_err_result(result, "Query name missing from key");
+        goto out;
+    }
+    zabbix_log(LOG_LEVEL_DEBUG, "Query name: %s", queryname);
+
+    // read the config file into memory
+    if(! config_read_file(&cfg, config_file)) {
+        set_err_result(result, "%s \"%s\"", config_error_text(&cfg), config_file);
+        goto out;
+    }
+
+    // get the query
+    if(! config_lookup_string(&cfg, queryname, &queryconst)) {
+        set_err_result(result, "Query \"%s\" not found in %s", queryname, config_file);
+        goto out;
+    }
+
+    // copy to non-constant
+    query = zbx_malloc(query, sizeof(char) * strlen(queryconst));
+    zbx_strlcpy(query, queryconst, strlen(queryconst));
+    zabbix_log(LOG_LEVEL_DEBUG, "Query retrieved: %s", query);
+
+    // parse user params
+    zabbix_log(LOG_LEVEL_DEBUG, "Appending %i params to query", request->nparam - 3);
+    for (i = 3; i < request->nparam; i++) {
+        params = param_append(params, get_rparam(request, i));
+    }
+
+    // Return the appropriate result type for this key
+    // as per `pg.query2.{type}`
+    if(0 == strncmp(&request->key[10], "string", 5))
+        ret = pg_get_string(request, result, query, params);
+
+    else if(0 == strncmp(&request->key[10], "integer", 7))
+        ret = pg_get_int(request, result, query, params);
+
+    else if(0 == strncmp(&request->key[10], "double", 6))
+        ret = pg_get_dbl(request, result, query, params);
+
+    else if(0 == strncmp(&request->key[10], "discovery", 9))
+        ret = pg_get_discovery(request, result, query, params);
+
+    else
+        set_err_result(result, "Unsupported query type: %s", request->key[10]);
+
+    zbx_free(query);
+
+out:
+    config_destroy(&cfg);
+    zabbix_log(LOG_LEVEL_DEBUG, "End of %s()", __function_name);
+    return ret;
+}


### PR DESCRIPTION
I've created a new function pg_query2 to provide new pg.query2.* keys to read SQL from a key/value config file instead of from the zabbix key itself.  This will eliminate the zabbix limitation of 255 bytes for the key length with regard to SQL.

This will allow users to create lengthy SQL calls without creating a long zabbix key loaded with SQL.

**I've added a sample query.conf file, but I don't know how to modify the rpm/deb packaging to create the required /etc/libzbxpgsql.d directory or deploy query.conf there automatically.**

**I also don't know how to modify the packaging to add the new dependency on the C libconfig library.**

I do have a concern about my code since I haven't coded any C in about 15 years, so please scrutinize it carefully for any issues, including memory allocation.

Thanks!
--Rob