### PR TITLE
Remove unnecessary address-of and type cast

### DIFF
--- a/src/libzbxpgsql.c
+++ b/src/libzbxpgsql.c
@@ -496,7 +496,7 @@ int set_err_result(AGENT_RESULT *result, const char *format, ...)
 
     // parse message string
     va_start (args, format);
-    zbx_vsnprintf((char*)&msg, sizeof(msg), format, args);
+    zbx_vsnprintf(msg, sizeof(msg), format, args);
 
     // log message
     zabbix_log(LOG_LEVEL_ERR, "PostgreSQL: %s", msg);


### PR DESCRIPTION
I am submitting this PR in continuation of our [discussion](https://github.com/cavaliercoder/libzbxpgsql/commit/fc0b4f9ad12996c8b21eb4d5cf87c6e3f410ce7c#r33266223). `msg` is defined as `char []` and therefore can be passed to `zbx_vsnprintf()` which expects `char *` without any additional operations.