### PR TITLE
Replace zbx_snprintf() function/macro with function pointer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,9 @@ if test ! "x$found_zabbix" = "xyes"; then
 	AC_MSG_ERROR([Zabbix headers not found])
 fi
 
+# Checking for libdl
+AC_CHECK_LIB(dl,dlopen)
+
 # output
 AC_CONFIG_FILES([
  Makefile

--- a/src/libzbxpgsql.h
+++ b/src/libzbxpgsql.h
@@ -43,7 +43,11 @@
 #define HAVE_TIME_H 1
 #include <sysinc.h>
 #include <module.h>
+#define zbx_snprintf any_name_is_better /* don't want common.h to declare zbx_snprintf() function */
 #include <common.h>
+#undef zbx_snprintf /* forget macro definition from old common.h and/or our own macro definition two lines above */
+#define zbx_snprintf pgsql_snprintf /* prevent symbol conflict with zbx_snprintf() function in new Zabbix binaries */
+extern size_t (*zbx_snprintf)(char *str, size_t count, const char *fmt, ...); /* use old name to avoid changing much of our code */
 #include <log.h>
 #include <zbxjson.h>
 #include <version.h>


### PR DESCRIPTION
...which is initialized in runtime. The idea is that instead of using `zbx_snprintf()` defined by Zabbix, module will define a function pointer with the same name and signature. Function pointer will be set to point either to `zbx_snprintf()` or `__zbx_zbx_snprintf()` depending on what Zabbix binary can provide. This will allow module to work with older Zabbix versions where `zbx_snprintf()` is a preprocessor macro wrapping `__zbx_zbx_snprintf()` function as well as with newer versions where `zbx_snprintf()` is a real function. Theoretically, it should not matter what version of Zabbix source was used to compile module binary. Hopefully, this resolves #139.